### PR TITLE
using a named function fix the stopListening bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,10 +117,12 @@ class EventEmitter {
    * @return {EventEmitter}
    */
   listenToOnce(obj, evt, listener, ctx) {
-    return this.listenTo(obj, evt, (...args) => {
+    let once = (...args) => {
       listener.call(ctx, ...args);
-      this.stopListening(obj, evt);
-    }, ctx);
+      this.stopListening(obj, evt, once);
+    }
+
+    return this.listenTo(obj, evt, once, ctx);
   }
 
   /**


### PR DESCRIPTION
Once an event was triggered and intercepted by `listenToOnce`, all the listeners attached to the event was deleted instead of just the one attached to `listenToOnce` because the third parameter of `stopListening` was missing.
